### PR TITLE
Add a flag to disable TCP scanning

### DIFF
--- a/internal/setting/app.go
+++ b/internal/setting/app.go
@@ -41,6 +41,7 @@ type settings struct {
 	TrustedPortHeader   string
 	EnableSecureHeaders bool
 	EnableHTTP3         bool
+	DisableTCPScan      bool
 	Server              serverSettings
 	Resolver            resolver
 	version             bool
@@ -97,6 +98,12 @@ func Setup(args []string) (output string, err error) {
 		"trusted-port-header",
 		"",
 		"Trusted request header for remote client port (e.g. X-Real-Port). When this parameter is set -trusted-header becomes mandatory",
+	)
+	flags.BoolVar(
+		&App.DisableTCPScan,
+		"disable-scan",
+		false,
+		"Disable TCP port scanning functionality",
 	)
 	flags.BoolVar(&App.version, "version", false, "Output version information and exit")
 	flags.BoolVar(

--- a/internal/setting/app.go
+++ b/internal/setting/app.go
@@ -99,12 +99,6 @@ func Setup(args []string) (output string, err error) {
 		"",
 		"Trusted request header for remote client port (e.g. X-Real-Port). When this parameter is set -trusted-header becomes mandatory",
 	)
-	flags.BoolVar(
-		&App.DisableTCPScan,
-		"disable-scan",
-		false,
-		"Disable TCP port scanning functionality",
-	)
 	flags.BoolVar(&App.version, "version", false, "Output version information and exit")
 	flags.BoolVar(
 		&App.EnableSecureHeaders,
@@ -117,6 +111,12 @@ func Setup(args []string) (output string, err error) {
 		"enable-http3",
 		false,
 		"Enable HTTP/3 protocol. HTTP/3 requires --tls-bind set, as HTTP/3 starts as a TLS connection that then gets upgraded to UDP. The UDP port is the same as the one used for the TLS server.",
+	)
+	flags.BoolVar(
+		&App.DisableTCPScan,
+		"disable-scan",
+		false,
+		"Disable TCP port scanning functionality",
 	)
 
 	err = flags.Parse(args)

--- a/router/setup.go
+++ b/router/setup.go
@@ -24,7 +24,9 @@ func SetupTemplate(r *gin.Engine) {
 func Setup(r *gin.Engine, geo *service.Geo) {
 	geoSvc = geo
 	r.GET("/", getRoot)
-	r.GET("/scan/tcp/:port", scanTCPPort)
+	if !setting.App.DisableTCPScan {
+		r.GET("/scan/tcp/:port", scanTCPPort)
+	}
 	r.GET("/client-port", getClientPortAsString)
 	r.GET("/geo", getGeoAsString)
 	r.GET("/geo/:field", getGeoAsString)


### PR DESCRIPTION
Adds a flag (-disable-scan) that when set, blocks the registration of the tcp scan route.

This is not a desirable feature as we don't want someone to be able to enumerate the firewall configuration between them and us.

Disclaimer: my experience with go is minimal, and I've never used gin/httprouter - there may be a better approach.